### PR TITLE
Release 1.11 release notes document template with proposed tags

### DIFF
--- a/releases/release-1.11/release_notes_draft.md
+++ b/releases/release-1.11/release_notes_draft.md
@@ -1,0 +1,33 @@
+# Kubernetes 1.11 Release Notes
+
+This document is for release notes for Kubernetes 1.11. These release notes are initially generated from commit messages, and are sorted based on the release note tag.
+
+Commits should be tagged as follows:
+
+**/release-note-before-upgrading**
+
+This tag is for urgent changes that users must take into consideration before upgrading. For example, mandatory upgrades of dependencies or other upgrade/downgrade issues belong in this category.
+
+**/release-note-feature**
+
+This tag is for changes that are related to major features that are listed in the feature tracking spreadsheet.
+
+**/release-note**
+
+This tag is for changes that are user-facing. For example, API changes or CLI flag changes belong in this category. Fixed bugs that affect the user experience should also be in this category.
+
+**/release-note-none**
+
+This tag is for changes that don't affect the user experience, such as behind-the-scenes improvements that only other Kubernetes developers will notice. These notes will appear in the changelog but not the release notes.
+
+## Before Upgrading
+
+This section includes /release-notes-before-upgrading changes.
+
+## Major Themes
+
+This section includes /release-notes-feature changes.
+
+## Other Notable Changes
+
+This section includes /release-note changes.


### PR DESCRIPTION
This document is the skeleton for the release notes for Kubernetes Release 1.11.  It includes explanations of four separate release-note-related tags, two of which (release-note-before-upgrading and release-note-feature) do not yet exist, and will have to be created.